### PR TITLE
Fix mypy configuration and tighten typing coverage

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -7,7 +7,4 @@ disallow_any_generics = True
 disallow_subclassing_any = True
 no_implicit_optional = True
 show_error_codes = True
-exclude = (?x)(
-^third_party/|
-^packaging/
-)
+exclude = (?x)(^third_party/|^packaging/)

--- a/src/decree/core.py
+++ b/src/decree/core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import NoReturn
 from pathlib import Path
 
 from beartype import beartype
@@ -99,15 +100,16 @@ class AdrLog:
         slug = slugify(title)
         path = self.dir / f"{number:04d}-{slug}.md"
         tpl = template.read_text(encoding="utf-8") if template else DEFAULT_TEMPLATE
+        record_date = date or resolve_date()
         content = tpl.format(
             number=number,
             title=title,
             status=status.value,
-            date=(date or resolve_date()),
+            date=record_date,
         )
         path.write_text(content, encoding="utf-8", newline="\n")
         return AdrRecord(
-            number=number, slug=slug, title=title, status=status, date=resolve_date(), path=path
+            number=number, slug=slug, title=title, status=status, date=record_date, path=path
         )
 
 
@@ -143,5 +145,5 @@ def _reverse_rel(rel: str) -> str:
     return mapping.get(rel, f"{rel} (reverse)")
 
 
-def _raise(exc: Exception) -> None:
+def _raise(exc: Exception) -> NoReturn:
     raise exc

--- a/src/decree/utils.py
+++ b/src/decree/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 import unicodedata
+from collections.abc import Mapping
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
@@ -13,9 +14,9 @@ def slugify(title: str) -> str:
     return s.strip("-")
 
 
-def resolve_date(env: dict[str, str] | None = None) -> str:
-    env = env or os.environ
-    if d := env.get("ADR_DATE"):
+def resolve_date(env: Mapping[str, str] | None = None) -> str:
+    actual_env: Mapping[str, str] = os.environ if env is None else env
+    if d := actual_env.get("ADR_DATE"):
         return d
-    tz = env.get("DECREE_TZ", "UTC")
+    tz = actual_env.get("DECREE_TZ", "UTC")
     return datetime.now(ZoneInfo(tz)).strftime("%Y-%m-%d")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import pytest
 
 
 @pytest.fixture(autouse=True)
-def _clean_env(monkeypatch: pytest.MonkeyPatch):
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     for k in ("ADR_DATE", "DECREE_TZ", "ADR_TEMPLATE"):
         monkeypatch.delenv(k, raising=False)
     yield

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from decree.core import AdrLog
 
 
-def test_init_seeds_0001(tmp_path: Path):
+def test_init_seeds_0001(tmp_path: Path) -> None:
     log = AdrLog.init(tmp_path / "doc" / "adr")
     p = tmp_path / "doc" / "adr" / "0001-record-architecture-decisions.md"
     assert p.exists()

--- a/tests/test_date_envs.py
+++ b/tests/test_date_envs.py
@@ -1,12 +1,14 @@
+import pytest
+
 from decree.utils import resolve_date
 
 
-def test_adr_date_verbatim(monkeypatch):
+def test_adr_date_verbatim(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ADR_DATE", "1999-12-31")
     assert resolve_date() == "1999-12-31"
 
 
-def test_deceree_tz_changes_format(monkeypatch):
+def test_deceree_tz_changes_format(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DECREE_TZ", "UTC")
     d = resolve_date()
     assert len(d) == 10 and d[4] == "-" and d[7] == "-"

--- a/tests/test_new_list_toc.py
+++ b/tests/test_new_list_toc.py
@@ -4,7 +4,7 @@ from decree.core import AdrLog
 from decree.models import AdrStatus
 
 
-def test_new_list_and_toc(tmp_path: Path):
+def test_new_list_and_toc(tmp_path: Path) -> None:
     log = AdrLog.init(tmp_path / "doc" / "adr")
     log.new("Use beartype on public API", status=AdrStatus.Accepted)
     rows = list(log.list())

--- a/tests/test_slugify.py
+++ b/tests/test_slugify.py
@@ -1,7 +1,7 @@
 from decree.utils import slugify
 
 
-def test_slugify_rules():
+def test_slugify_rules() -> None:
     assert slugify("Hello, World!") == "hello-world"
     assert slugify("Ünicode → ASCII") == "unicode-ascii"
     assert slugify("  many---separators___ ") == "many-separators"


### PR DESCRIPTION
## Summary
- fix the mypy exclude regex and satisfy strict typing in utilities and tests
- ensure ADR creation keeps a consistent resolved date and mark helper as NoReturn
- add explicit fixture and test annotations required by the strict mypy configuration

## Testing
- uv run mypy src tests
- uv run pytest
- pre-commit run --all-files *(fails: markdownlint nodeenv bootstrap requires external network and exits with an SSL certificate error)*

------
https://chatgpt.com/codex/tasks/task_e_68e4720714108326b7f80d65e09cbc42