### PR TITLE
Add explicit Python 3.13 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]  # , windows-latest]
-        python-version: ["3.11", "3.12"]
+    python-version: ["3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import nox
 
-PY = ["3.11", "3.12"]
+PY = ["3.11", "3.12", "3.13"]
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
 "Programming Language :: Python :: 3",
 "Programming Language :: Python :: 3.11",
 "Programming Language :: Python :: 3.12",
+"Programming Language :: Python :: 3.13",
 "Environment :: Console",
 "Topic :: Documentation",
 ]


### PR DESCRIPTION
## Summary
- declare Python 3.13 in the project classifiers
- extend the nox Python matrix to cover 3.13
- run GitHub Actions CI against Python 3.13

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4a7308b888326b4f0fcee3de83c17