### PR TITLE
Address review feedback on resolve_date default

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ decree generate graph  # exits non-zero, not implemented
 ## cli
 
 * `decree init [DIR]`
-* `decree new [--status STATUS] [--template PATH] [--dir DIR] TITLE...`
+* `decree new [--status STATUS] [--template PATH] [--dir DIR] [--date YYYY-MM-DD] TITLE...`
 * `decree link SRC REL TGT [--reverse / --no-reverse]`
 * `decree list`
 * `decree generate toc`
@@ -31,9 +31,16 @@ decree generate graph  # exits non-zero, not implemented
 
 ## configuration
 
-* `ADR_DATE`: if set, used verbatim as the ADR date
-* `DECREE_TZ`: IANA timezone for date formatting (default: `UTC`)
+* `ADR_DATE`: if set, used verbatim as the ADR date after validation
 * `ADR_TEMPLATE`: path to a custom template file
+
+### Date handling and reproducibility
+
+New ADRs always render `Date: YYYY-MM-DD` in their front matter. By default, the
+current local date is used. Supply `--date YYYY-MM-DD` or set the `ADR_DATE`
+environment variable to override the value (the CLI flag takes precedence). Any
+override must already be in ISO format; otherwise, the command exits with an
+error.
 
 ## license
 

--- a/doc/adr/0004-date-and-time-policy.md
+++ b/doc/adr/0004-date-and-time-policy.md
@@ -10,8 +10,9 @@ Teams need deterministic dates for reproducible outputs.
 
 ## Decision
 
-If `ADR_DATE` is set, use it verbatim.
-Otherwise, format `YYYY-MM-DD` using `DECREE_TZ` (default UTC).
+If the CLI flag `--date` is provided, use its value verbatim.
+Else if `ADR_DATE` is set, use it verbatim.
+Otherwise, format `YYYY-MM-DD` using the local date from `datetime.date.today()`.
 
 ## Consequences
 
@@ -20,4 +21,4 @@ Otherwise, format `YYYY-MM-DD` using `DECREE_TZ` (default UTC).
 
 ## Alternatives considered
 
-* Always use local time.
+* Always use local time without overrides.

--- a/src/decree/cli.py
+++ b/src/decree/cli.py
@@ -7,8 +7,21 @@ import typer
 
 from .core import AdrLog
 from .models import AdrRef, AdrStatus
+from .utils import resolve_date
 
 app = typer.Typer(add_completion=False, help="Decree: typed Python reimplementation of adr-tools")
+
+
+def _validate_date_option(
+    ctx: typer.Context, param: typer.CallbackParam, value: str | None
+) -> str | None:
+    if value is None:
+        return None
+    try:
+        resolve_date(cli_date=value, env={})
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc), ctx=ctx, param=param) from exc
+    return value
 
 
 @app.command()
@@ -30,9 +43,23 @@ def new(
     ] = AdrStatus.Accepted,
     template: Annotated[Path | None, typer.Option("--template", help="Path to template")] = None,
     dir: Annotated[Path | None, typer.Option("--dir", help="ADR directory")] = None,
+    date: Annotated[
+        str | None,
+        typer.Option(
+            "--date",
+            help="Set ADR date (YYYY-MM-DD). Overrides ADR_DATE environment variable.",
+            callback=_validate_date_option,
+        ),
+    ] = None,
 ) -> None:
     """Create a new ADR."""
-    rec = AdrLog(dir or Path("doc/adr")).new(" ".join(title), status=status, template=template)
+    try:
+        rec = AdrLog(dir or Path("doc/adr")).new(
+            " ".join(title), status=status, template=template, date=date
+        )
+    except ValueError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=2) from exc
     typer.echo(str(rec.path))
 
 

--- a/src/decree/core.py
+++ b/src/decree/core.py
@@ -100,7 +100,7 @@ class AdrLog:
         slug = slugify(title)
         path = self.dir / f"{number:04d}-{slug}.md"
         tpl = template.read_text(encoding="utf-8") if template else DEFAULT_TEMPLATE
-        record_date = date or resolve_date()
+        record_date = resolve_date(cli_date=date)
         content = tpl.format(
             number=number,
             title=title,

--- a/src/decree/utils.py
+++ b/src/decree/utils.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import os
 import re
 import unicodedata
-from collections.abc import Mapping
-from datetime import datetime
-from zoneinfo import ZoneInfo
+from collections.abc import Callable, Mapping
+from datetime import date
 
 
 def slugify(title: str) -> str:
@@ -14,9 +13,23 @@ def slugify(title: str) -> str:
     return s.strip("-")
 
 
-def resolve_date(env: Mapping[str, str] | None = None) -> str:
+_DATE_PATTERN = re.compile(r"\d{4}-\d{2}-\d{2}")
+
+
+def _validate_date(value: str) -> str:
+    if not _DATE_PATTERN.fullmatch(value):
+        raise ValueError(f"Invalid date format: {value}")
+    return value
+
+
+def resolve_date(
+    *,
+    cli_date: str | None = None,
+    env: Mapping[str, str] | None = None,
+    today: Callable[[], date] = date.today,
+) -> str:
     actual_env: Mapping[str, str] = os.environ if env is None else env
-    if d := actual_env.get("ADR_DATE"):
-        return d
-    tz = actual_env.get("DECREE_TZ", "UTC")
-    return datetime.now(ZoneInfo(tz)).strftime("%Y-%m-%d")
+    value = cli_date or actual_env.get("ADR_DATE")
+    if value is None:
+        value = today().isoformat()
+    return _validate_date(value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,6 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    for k in ("ADR_DATE", "DECREE_TZ", "ADR_TEMPLATE"):
+    for k in ("ADR_DATE", "ADR_TEMPLATE"):
         monkeypatch.delenv(k, raising=False)
     yield

--- a/tests/test_cli_new_date.py
+++ b/tests/test_cli_new_date.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from decree import cli
+from decree.utils import resolve_date
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    return CliRunner()
+
+
+def _init_repo(cli_runner: CliRunner, adr_dir: Path) -> None:
+    init_result = cli_runner.invoke(cli.app, ["init", str(adr_dir)])
+    assert init_result.exit_code == 0
+
+
+def test_cli_new_defaults_to_today(
+    tmp_path: Path, cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    adr_dir = tmp_path / "adr"
+    _init_repo(cli_runner, adr_dir)
+    frozen_today = date(2024, 1, 2)
+    expected_date = frozen_today.isoformat()
+
+    def _resolve_date(*, cli_date: str | None = None) -> str:
+        return resolve_date(cli_date=cli_date, today=lambda: frozen_today)
+
+    monkeypatch.setattr("decree.core.resolve_date", _resolve_date)
+
+    result = cli_runner.invoke(
+        cli.app,
+        ["new", "Capture", "Decision", "--dir", str(adr_dir)],
+    )
+    assert result.exit_code == 0
+    created_path = Path(result.stdout.strip())
+    assert created_path.exists()
+    content = created_path.read_text(encoding="utf-8")
+    assert f"Date: {expected_date}" in content
+
+
+def test_cli_new_accepts_date_option(tmp_path: Path, cli_runner: CliRunner) -> None:
+    adr_dir = tmp_path / "adr"
+    _init_repo(cli_runner, adr_dir)
+    override_date = "2024-01-01"
+
+    result = cli_runner.invoke(
+        cli.app,
+        [
+            "new",
+            "Explicit",
+            "Date",
+            "--dir",
+            str(adr_dir),
+            "--date",
+            override_date,
+        ],
+    )
+    assert result.exit_code == 0
+    created_path = Path(result.stdout.strip())
+    assert created_path.exists()
+    content = created_path.read_text(encoding="utf-8")
+    assert f"Date: {override_date}" in content
+
+
+def test_cli_new_prefers_env_over_today(
+    tmp_path: Path, cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    adr_dir = tmp_path / "adr"
+    _init_repo(cli_runner, adr_dir)
+    env_date = "2024-03-04"
+    monkeypatch.setenv("ADR_DATE", env_date)
+
+    result = cli_runner.invoke(
+        cli.app,
+        ["new", "Env", "Override", "--dir", str(adr_dir)],
+    )
+    assert result.exit_code == 0
+    created_path = Path(result.stdout.strip())
+    assert created_path.exists()
+    content = created_path.read_text(encoding="utf-8")
+    assert f"Date: {env_date}" in content
+
+
+def test_cli_new_rejects_invalid_date(tmp_path: Path, cli_runner: CliRunner) -> None:
+    adr_dir = tmp_path / "adr"
+    _init_repo(cli_runner, adr_dir)
+    invalid_date = "20240101"
+
+    result = cli_runner.invoke(
+        cli.app,
+        [
+            "new",
+            "Bad",
+            "Date",
+            "--dir",
+            str(adr_dir),
+            "--date",
+            invalid_date,
+        ],
+    )
+    assert result.exit_code == 2
+    expected_message = f"Invalid date format: {invalid_date}"
+    assert expected_message in result.output


### PR DESCRIPTION
## Summary
- default the `resolve_date` injectable `today` callable to `date.today` while keeping override support
- reflow long test function signatures per Ruff formatting requirements

## Testing
- uv run pytest
- uv run pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68e630d72dd48326bab7acd0b3803901