### PR TITLE
Refine Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+# .github/dependabot.yml
+version: 2
+
+# Use uv if the project uses uv.lock. Keep pip as a fallback if not.
+updates:
+  # Python via uv (enable this block only if uv.lock exists)
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    groups:
+      runtime:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      dev-tools:
+        patterns:
+          - "ruff*"
+          - "mypy*"
+          - "pytest*"
+          - "nox*"
+          - "hypothesis*"
+          - "sphinx*"
+        update-types: ["minor", "patch"]
+    labels: ["dependencies", "security"]
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  # Keep GitHub Actions up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    groups:
+      actions:
+        patterns: ["*"]
+    labels: ["dependencies", "security", "github-actions"]
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ version: 2
 
 # Use uv if the project uses uv.lock. Keep pip as a fallback if not.
 updates:
-  # Python via uv (enable this block only if uv.lock exists)
+  # Python via uv
   - package-ecosystem: "uv"
     directory: "/"
     schedule:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ ADR_TEMPLATE=/path/to/template.md decree new "Use beartype"
 decree new --template /other/path.md "Use beartype"  # CLI overrides env var
 ```
 
+## dependabot
+
+Dependabot checks uv dependencies and GitHub Actions every Monday at 09:00 America/Los_Angeles.
+Edit `.github/dependabot.yml` to change the schedule window,
+and adjust the `groups` block if you want different buckets for runtime versus dev tooling updates.
+
 ### Date handling and reproducibility
 
 New ADRs always render `Date: YYYY-MM-DD` in their front matter. By default, the


### PR DESCRIPTION
## Summary
- align the Dependabot config with uv-based updates, grouped dev tooling, and weekly 09:00 America/Los_Angeles runs for both Python and Actions
- note in the README how to adjust the schedule and dependency groups

## Testing
- python -m pre_commit run --all-files

## Security
- Ensure Dependabot security updates remain enabled from **Settings → Code security and analysis** so CVE patches arrive automatically.


------
https://chatgpt.com/codex/tasks/task_e_68e76b205fe4832697ae8a4f30315762