### PR TITLE
Enable all stable Ruff rules, auto-fix, and wire into pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 ---
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.14.0
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,5 @@
+"""Automation sessions for local development."""
+
 from __future__ import annotations
 
 import nox
@@ -7,30 +9,35 @@ PY = ["3.11", "3.12", "3.13"]
 
 @nox.session
 def lint(session: nox.Session) -> None:
+    """Run Ruff's lint pass across the repository."""
     session.install("ruff")
     session.run("ruff", "check", ".")
 
 
 @nox.session
 def typecheck(session: nox.Session) -> None:
+    """Execute mypy in strict mode against sources and tests."""
     session.install("mypy", "beartype")
     session.run("mypy", "src", "tests")
 
 
 @nox.session(python=PY)
 def tests(session: nox.Session) -> None:
+    """Run the pytest suite under the supported Python versions."""
     session.install(".[dev]")
     session.run("pytest", "-q")
 
 
 @nox.session
 def build(session: nox.Session) -> None:
+    """Create source and wheel distributions."""
     session.install("uv-build")
     session.run("python", "-m", "uv_build", "sdist", "bdist_wheel")
 
 
 @nox.session
 def release_dry_run(session: nox.Session) -> None:
+    """Build distributions and ensure they pass Twine's validation."""
     session.install("uv-build", "twine")
     session.run("python", "-m", "uv_build", "sdist", "bdist_wheel")
     session.run("twine", "check", "dist/*")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,20 @@ line-length = 100
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "UP", "B", "SIM", "PERF", "RUF", "ANN"]
-ignore = ["ANN101", "ANN102"]  # self and cls annotations are redundant
+select = ["ALL"]  # enable all stable rule families
+ignore = ["COM812"]  # avoid formatter conflicts with ruff-format
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = [
+    "D100",  # tests do not require module-level docstrings
+    "D101",  # tests do not require class docstrings
+    "D102",  # tests do not require method docstrings
+    "D103",  # tests do not require function docstrings
+    "S101",  # pytest assertions rely on bare assert statements
+]
+"tests/test_cli_success_paths.py" = [
+    "SLF001",  # tests intentionally exercise a private helper for error handling
+]
 
 [tool.mypy]
 python_version = "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,11 @@ target-version = "py311"
 
 [tool.ruff.lint]
 select = ["ALL"]  # enable all stable rule families
-ignore = ["COM812"]  # avoid formatter conflicts with ruff-format
+ignore = [
+    "COM812",  # avoid formatter conflicts with ruff-format
+    "D203",    # incompatible with D211 (no-blank-line-before-class)
+    "D213",    # incompatible with D212 (multi-line-summary-first-line)
+]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,8 @@ select = ["ALL"]  # enable all stable rule families
 ignore = [
     "COM812",  # avoid formatter conflicts with ruff-format
     "D203",    # incompatible with D211 (no-blank-line-before-class)
-    "D213",    # incompatible with D212 (multi-line-summary-first-line)
+    "D213",    # incompatible with D212 (multi-line-summary-first-line
+    "TC003",   # type annotation only imports are used by beartype at runtime.
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Support scripts for release automation."""

--- a/scripts/set_version_from_tag.py
+++ b/scripts/set_version_from_tag.py
@@ -1,34 +1,58 @@
+"""Update ``pyproject.toml`` using the most recent Git tag."""
+
 from __future__ import annotations
 
 import os
-import pathlib
 import re
 import subprocess
+import sys
+from pathlib import Path
+from shutil import which
 
-root = pathlib.Path(__file__).resolve().parents[1]
-tag = (
-    os.getenv("GIT_TAG")
-    or subprocess.check_output(
+
+def resolve_tag() -> str:
+    """Return the version tag from the environment or the Git repository."""
+    tag = os.getenv("GIT_TAG")
+    if tag:
+        return tag
+
+    git_executable = which("git")
+    if git_executable is None:
+        message = "git executable is required to resolve tags"
+        raise SystemExit(message)
+
+    return subprocess.check_output(  # noqa: S603  # command uses absolute path from `which`
         [
-            "git",
+            git_executable,
             "describe",
             "--tags",
             "--abbrev=0",
-        ]
-    )
-    .decode()
-    .strip()
-)
-m = re.fullmatch(r"v(\d+\.\d+\.\d+)", tag)
-if not m:
-    raise SystemExit("Tag must look like vX.Y.Z")
-version = m.group(1)
+        ],
+        text=True,
+        encoding="utf-8",
+    ).strip()
 
-pyproject = (root / "pyproject.toml").read_text(encoding="utf-8")
-pyproject = re.sub(
-    r'(?m)^version\s*=\s*"[0-9]+\.[0-9]+\.[0-9]+"\s*#.*$',
-    f'version = "{version}"  # updated from tag',
-    pyproject,
-)
-(root / "pyproject.toml").write_text(pyproject, encoding="utf-8")
-print(f"Set version to {version}")
+
+def main() -> None:
+    """Write the resolved version into ``pyproject.toml``."""
+    root = Path(__file__).resolve().parents[1]
+    tag = resolve_tag()
+    match = re.fullmatch(r"v(\d+\.\d+\.\d+)", tag)
+    if match is None:
+        message = "Tag must look like vX.Y.Z"
+        raise SystemExit(message)
+    version = match.group(1)
+
+    pyproject_path = root / "pyproject.toml"
+    pyproject = pyproject_path.read_text(encoding="utf-8")
+    updated = re.sub(
+        r'(?m)^version\s*=\s*"[0-9]+\.[0-9]+\.[0-9]+"\s*#.*$',
+        f'version = "{version}"  # updated from tag',
+        pyproject,
+    )
+    pyproject_path.write_text(updated, encoding="utf-8")
+    sys.stdout.write(f"Set version to {version}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/decree/__init__.py
+++ b/src/decree/__init__.py
@@ -1,3 +1,5 @@
+"""Public package exports for the :mod:`decree` library."""
+
 from __future__ import annotations
 
 __all__ = ["AdrLog", "AdrRecord", "AdrRef", "AdrStatus", "ExitCode", "LinkSpec"]

--- a/src/decree/__main__.py
+++ b/src/decree/__main__.py
@@ -1,3 +1,5 @@
+"""Command-line entrypoint for ``python -m decree``."""
+
 from .cli import main
 
 # The module-level entrypoint is invoked by ``python -m decree`` which runs in a

--- a/src/decree/cli.py
+++ b/src/decree/cli.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Callable
 from pathlib import Path
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 import click
 import typer
@@ -15,6 +14,9 @@ from .exitcodes import ExitCode, exit_with
 from .models import AdrRef, AdrStatus
 from .title import sync_titles, update_title
 from .utils import resolve_date
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 app = typer.Typer(add_completion=False, help="Decree: typed Python reimplementation of adr-tools")
 title_app = typer.Typer(add_completion=False, help="Manage ADR titles.")
@@ -201,7 +203,6 @@ def title_set(
     ] = False,
 ) -> None:
     """Update an ADR title."""
-
     update_title(
         _title_dir(dir),
         target,
@@ -224,7 +225,6 @@ def title_sync(
     ] = False,
 ) -> None:
     """Sync ADR filenames and headings with their titles."""
-
     sync_titles(
         _title_dir(dir),
         rename=rename,

--- a/src/decree/core.py
+++ b/src/decree/core.py
@@ -2,14 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable as _Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-else:  # pragma: no cover - runtime alias for type checking compatibility
-    Iterable = _Iterable
 
 from beartype import beartype
 

--- a/src/decree/core.py
+++ b/src/decree/core.py
@@ -1,8 +1,15 @@
+"""Core domain logic for manipulating ADR repositories."""
+
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable as _Iterable
 from pathlib import Path
-from typing import NoReturn
+from typing import TYPE_CHECKING, NoReturn
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+else:  # pragma: no cover - runtime alias for type checking compatibility
+    Iterable = _Iterable
 
 from beartype import beartype
 
@@ -78,14 +85,18 @@ def unlink_adr(src: Path, rel: str, tgt: Path, *, reverse: bool = True) -> None:
 
 
 class AdrLog:
-    def __init__(self, dir: Path) -> None:
-        self.dir = dir
+    """High-level operations for working with ADR repositories."""
+
+    def __init__(self, directory: Path) -> None:
+        """Create an ADR log bound to ``directory``."""
+        self.dir = directory
 
     @classmethod
     @beartype
-    def init(cls, dir: Path | None = None) -> AdrLog:
+    def init(cls, directory: Path | None = None) -> AdrLog:
+        """Initialise an ADR repository, seeding record 0001 when absent."""
         base = Path.cwd()
-        adr_dir = (dir or (base / ADR_DIR_DEFAULT)).resolve()
+        adr_dir = (directory or (base / ADR_DIR_DEFAULT)).resolve()
         adr_dir.mkdir(parents=True, exist_ok=True)
         log = cls(adr_dir)
         first = adr_dir / "0001-record-architecture-decisions.md"
@@ -102,11 +113,13 @@ class AdrLog:
         template: Path | None = None,
         date: str | None = None,
     ) -> AdrRecord:
+        """Write a new ADR entry to disk and return the resulting record."""
         next_num = self._next_number()
         return self._write(next_num, title, status, template, date)
 
     @beartype
     def list(self) -> Iterable[AdrRecord]:
+        """Yield all ADR records sorted by numeric identifier."""
         for path in sorted(self.dir.glob("[0-9][0-9][0-9][0-9]-*.md")):
             number = int(path.name[:4])
             title = _read_title(path)
@@ -122,29 +135,35 @@ class AdrLog:
 
     @beartype
     def link(self, src: AdrRef, rel: str, tgt: AdrRef, *, reverse: bool = False) -> None:
+        """Link two ADRs optionally inserting the reverse relationship."""
         s = self._path_for(src.number)
         t = self._path_for(tgt.number)
         link_adr(s, rel, t, reverse=reverse)
 
     @beartype
     def unlink(self, src: AdrRef, rel: str, tgt: AdrRef, *, reverse: bool = False) -> None:
+        """Remove a relationship between two ADRs."""
         s = self._path_for(src.number)
         t = self._path_for(tgt.number)
         unlink_adr(s, rel, t, reverse=reverse)
 
     @beartype
     def generate_toc(self) -> str:
+        """Produce a Markdown table of contents for the ADR log."""
         lines = ["# Architecture decision records", ""]
         for rec in self.list():
             rel = rec.path.relative_to(self.dir)
             lines.append(
-                f"- {rec.number:04d}. [{rec.title}]({rel.as_posix()}) — {rec.status} ({rec.date})"
+                f"- {rec.number:04d}. [{rec.title}]({rel.as_posix()}) — {rec.status} ({rec.date})",
             )
         return "\n".join(lines) + "\n"
 
     @beartype
     def upgrade(self) -> None:
-        self.dir.exists() or (_raise(FileNotFoundError(f"{self.dir} does not exist")))
+        """Perform idempotent repository upgrade tasks."""
+        if not self.dir.exists():
+            message = f"{self.dir} does not exist"
+            _raise(FileNotFoundError(message))
         (self.dir / ".decree").mkdir(exist_ok=True)
         (self.dir / ".decree" / "upgrade.marker").write_text("v1", encoding="utf-8")
 
@@ -155,7 +174,8 @@ class AdrLog:
     def _path_for(self, number: int) -> Path:
         for p in self.dir.glob(f"{number:04d}-*.md"):
             return p
-        raise FileNotFoundError(f"ADR {number:04d} not found")
+        message = f"ADR {number:04d} not found"
+        raise FileNotFoundError(message)
 
     def _write(
         self,
@@ -177,7 +197,12 @@ class AdrLog:
         )
         path.write_text(content, encoding="utf-8", newline="\n")
         return AdrRecord(
-            number=number, slug=slug, title=title, status=status, date=record_date, path=path
+            number=number,
+            slug=slug,
+            title=title,
+            status=status,
+            date=record_date,
+            path=path,
         )
 
 
@@ -185,7 +210,8 @@ def _read_title(path: Path) -> str:
     for line in path.read_text(encoding="utf-8").splitlines():
         if line.startswith("# "):
             parts = line[2:].split(":", 1)
-            return parts[1].strip() if len(parts) == 2 else parts[0].strip()
+            parts_with_label = 2
+            return parts[1].strip() if len(parts) == parts_with_label else parts[0].strip()
     return path.stem
 
 

--- a/src/decree/core.py
+++ b/src/decree/core.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
-from typing import TYPE_CHECKING, NoReturn
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable
+from typing import NoReturn
 
 from beartype import beartype
 
@@ -115,7 +113,7 @@ class AdrLog:
         return self._write(next_num, title, status, template, date)
 
     @beartype
-    def list(self) -> Iterable[AdrRecord]:
+    def list(self) -> Iterator[AdrRecord]:
         """Yield all ADR records sorted by numeric identifier."""
         for path in sorted(self.dir.glob("[0-9][0-9][0-9][0-9]-*.md")):
             number = int(path.name[:4])

--- a/src/decree/exitcodes.py
+++ b/src/decree/exitcodes.py
@@ -46,9 +46,8 @@ class ExitCode(IntEnum):
 
 def exit_with(code: ExitCode, msg: str | None = None) -> NoReturn:
     """Exit the interpreter with ``code`` optionally emitting ``msg`` to stderr."""
-
     if msg:
-        print(msg, file=sys.stderr)
+        sys.stderr.write(f"{msg}\n")
     raise SystemExit(int(code))
 
 

--- a/src/decree/models.py
+++ b/src/decree/models.py
@@ -1,12 +1,19 @@
+"""Data structures used throughout the Decree package."""
+
 from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import StrEnum
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class AdrStatus(StrEnum):
+    """Permitted lifecycle states for an architecture decision record."""
+
     Accepted = "Accepted"
     Proposed = "Proposed"
     Superseded = "Superseded"
@@ -16,11 +23,15 @@ class AdrStatus(StrEnum):
 
 @dataclass(frozen=True, slots=True)
 class AdrRef:
+    """Reference to an ADR by its numeric identifier."""
+
     number: int
 
 
 @dataclass(frozen=True, slots=True)
 class LinkSpec:
+    """Relationship request between two ADRs."""
+
     src: AdrRef
     rel: str
     tgt: AdrRef
@@ -29,6 +40,8 @@ class LinkSpec:
 
 @dataclass(frozen=True, slots=True)
 class AdrRecord:
+    """Materialized ADR entry as persisted on disk."""
+
     number: int
     slug: str
     title: str

--- a/src/decree/templates.py
+++ b/src/decree/templates.py
@@ -1,3 +1,5 @@
+"""Built-in ADR templates and seed content."""
+
 from __future__ import annotations
 
 DEFAULT_TEMPLATE = """# {number}: {title}

--- a/src/decree/utils.py
+++ b/src/decree/utils.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import os
 import re
-import typing
 import unicodedata
 from datetime import date
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
 
 
 def slugify(title: str) -> str:
@@ -29,11 +32,11 @@ def _validate_date(value: str) -> str:
 def resolve_date(
     *,
     cli_date: str | None = None,
-    env: typing.Mapping[str, str] | None = None,
-    today: typing.Callable[[], date] = date.today,
+    env: Mapping[str, str] | None = None,
+    today: Callable[[], date] = date.today,
 ) -> str:
     """Resolve the ADR date using CLI input, environment overrides, or the system clock."""
-    actual_env: typing.Mapping[str, str] = os.environ if env is None else env
+    actual_env: Mapping[str, str] = os.environ if env is None else env
     value = cli_date or actual_env.get("ADR_DATE")
     if value is None:
         value = today().isoformat()

--- a/src/decree/utils.py
+++ b/src/decree/utils.py
@@ -1,13 +1,16 @@
+"""Utility helpers for string normalization and configuration resolution."""
+
 from __future__ import annotations
 
 import os
 import re
+import typing
 import unicodedata
-from collections.abc import Callable, Mapping
 from datetime import date
 
 
 def slugify(title: str) -> str:
+    """Return a filesystem-friendly slug for ``title``."""
     s = unicodedata.normalize("NFKD", title).encode("ascii", "ignore").decode()
     s = re.sub(r"[^a-zA-Z0-9]+", "-", s.lower())
     return s.strip("-")
@@ -18,17 +21,19 @@ _DATE_PATTERN = re.compile(r"\d{4}-\d{2}-\d{2}")
 
 def _validate_date(value: str) -> str:
     if not _DATE_PATTERN.fullmatch(value):
-        raise ValueError(f"Invalid date format: {value}")
+        message = f"Invalid date format: {value}"
+        raise ValueError(message)
     return value
 
 
 def resolve_date(
     *,
     cli_date: str | None = None,
-    env: Mapping[str, str] | None = None,
-    today: Callable[[], date] = date.today,
+    env: typing.Mapping[str, str] | None = None,
+    today: typing.Callable[[], date] = date.today,
 ) -> str:
-    actual_env: Mapping[str, str] = os.environ if env is None else env
+    """Resolve the ADR date using CLI input, environment overrides, or the system clock."""
+    actual_env: typing.Mapping[str, str] = os.environ if env is None else env
     value = cli_date or actual_env.get("ADR_DATE")
     if value is None:
         value = today().isoformat()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite package for decree."""

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI-focused tests for decree."""

--- a/tests/cli/test_exit_codes.py
+++ b/tests/cli/test_exit_codes.py
@@ -40,7 +40,14 @@ def run_cli(
 ) -> subprocess.CompletedProcess[str]:
     command = [*CLI, *args]
     final_env = _build_env(env or {}, python_paths)
-    return subprocess.run(command, cwd=cwd, capture_output=True, text=True, env=final_env)
+    return subprocess.run(  # noqa: S603 - command is built from trusted arguments
+        command,
+        check=False,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env=final_env,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/test_title.py
+++ b/tests/cli/test_title.py
@@ -99,7 +99,8 @@ def test_title_set_dry_run_leaves_files_unchanged(adr_dir: Path) -> None:
     assert "# 0005: Original" in source.read_text(encoding="utf-8")
 
 
-def test_title_set_rejects_paths_outside_directory(adr_dir: Path) -> None:
+@pytest.mark.usefixtures("adr_dir")
+def test_title_set_rejects_paths_outside_directory() -> None:
     external = Path("outside.md")
     external.write_text("# Heading\n", encoding="utf-8")
 

--- a/tests/cli/test_title.py
+++ b/tests/cli/test_title.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 from typer.testing import CliRunner
 
 from decree.cli import app
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 runner = CliRunner()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
-
 import pytest
 
 
 @pytest.fixture(autouse=True)
-def _clean_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     for k in ("ADR_DATE", "ADR_TEMPLATE"):
         monkeypatch.delenv(k, raising=False)
-    yield

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import importlib
+
 import click
 import pytest
 
@@ -27,6 +29,7 @@ def test_main_exception_handling(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     def fake_app(*, standalone_mode: bool) -> None:
+        _ = standalone_mode
         raise exc
 
     monkeypatch.setattr(cli, "app", fake_app)
@@ -42,7 +45,5 @@ def test_main_exception_handling(
 
 
 def test_main_module_importable() -> None:
-    import importlib
-
     module = importlib.import_module("decree.__main__")
     assert module.main is cli.main

--- a/tests/test_cli_new_date.py
+++ b/tests/test_cli_new_date.py
@@ -21,7 +21,9 @@ def _init_repo(cli_runner: CliRunner, adr_dir: Path) -> None:
 
 
 def test_cli_new_defaults_to_today(
-    tmp_path: Path, cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    cli_runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     adr_dir = tmp_path / "adr"
     _init_repo(cli_runner, adr_dir)
@@ -69,7 +71,9 @@ def test_cli_new_accepts_date_option(tmp_path: Path, cli_runner: CliRunner) -> N
 
 
 def test_cli_new_prefers_env_over_today(
-    tmp_path: Path, cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    cli_runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     adr_dir = tmp_path / "adr"
     _init_repo(cli_runner, adr_dir)
@@ -104,6 +108,7 @@ def test_cli_new_rejects_invalid_date(tmp_path: Path, cli_runner: CliRunner) -> 
             invalid_date,
         ],
     )
-    assert result.exit_code == 2
+    expected_exit_code = 2
+    assert result.exit_code == expected_exit_code
     expected_message = f"Invalid date format: {invalid_date}"
     assert expected_message in result.output

--- a/tests/test_cli_success_paths.py
+++ b/tests/test_cli_success_paths.py
@@ -49,7 +49,7 @@ def test_link_command(tmp_path: Path) -> None:
 def test_resolve_template_missing(tmp_path: Path) -> None:
     missing = tmp_path / "missing.md"
     with pytest.raises(click.ClickException) as excinfo:
-        cli._resolve_template_path(missing)
+        cli._resolve_template_path(missing)  # type: ignore[attr-defined]
     assert excinfo.value.exit_code == int(ExitCode.INPUT_MISSING)
 
 
@@ -57,7 +57,7 @@ def test_resolve_template_not_file(tmp_path: Path) -> None:
     directory = tmp_path / "dir"
     directory.mkdir()
     with pytest.raises(click.ClickException) as excinfo:
-        cli._resolve_template_path(directory)
+        cli._resolve_template_path(directory)  # type: ignore[attr-defined]
     assert excinfo.value.exit_code == int(ExitCode.INPUT_MISSING)
 
 
@@ -86,13 +86,13 @@ def test_resolve_template_unreadable(tmp_path: Path, monkeypatch: pytest.MonkeyP
 
     monkeypatch.setattr(Path, "exists", fake_exists)
     with pytest.raises(click.ClickException) as excinfo:
-        cli._resolve_template_path(template)
+        cli._resolve_template_path(template)  # type: ignore[attr-defined]
     assert excinfo.value.exit_code == int(ExitCode.UNAVAILABLE)
 
     monkeypatch.setattr(Path, "exists", original_exists)
     monkeypatch.setattr(Path, "open", fake_open)
     with pytest.raises(click.ClickException) as excinfo:
-        cli._resolve_template_path(template)
+        cli._resolve_template_path(template)  # type: ignore[attr-defined]
     assert excinfo.value.exit_code == int(ExitCode.INPUT_MISSING)
 
     monkeypatch.setattr(Path, "open", original_open)

--- a/tests/test_cli_success_paths.py
+++ b/tests/test_cli_success_paths.py
@@ -49,7 +49,7 @@ def test_link_command(tmp_path: Path) -> None:
 def test_resolve_template_missing(tmp_path: Path) -> None:
     missing = tmp_path / "missing.md"
     with pytest.raises(click.ClickException) as excinfo:
-        cli._resolve_template_path(missing)  # type: ignore[attr-defined]
+        cli._resolve_template_path(missing)
     assert excinfo.value.exit_code == int(ExitCode.INPUT_MISSING)
 
 
@@ -57,7 +57,7 @@ def test_resolve_template_not_file(tmp_path: Path) -> None:
     directory = tmp_path / "dir"
     directory.mkdir()
     with pytest.raises(click.ClickException) as excinfo:
-        cli._resolve_template_path(directory)  # type: ignore[attr-defined]
+        cli._resolve_template_path(directory)
     assert excinfo.value.exit_code == int(ExitCode.INPUT_MISSING)
 
 
@@ -86,13 +86,13 @@ def test_resolve_template_unreadable(tmp_path: Path, monkeypatch: pytest.MonkeyP
 
     monkeypatch.setattr(Path, "exists", fake_exists)
     with pytest.raises(click.ClickException) as excinfo:
-        cli._resolve_template_path(template)  # type: ignore[attr-defined]
+        cli._resolve_template_path(template)
     assert excinfo.value.exit_code == int(ExitCode.UNAVAILABLE)
 
     monkeypatch.setattr(Path, "exists", original_exists)
     monkeypatch.setattr(Path, "open", fake_open)
     with pytest.raises(click.ClickException) as excinfo:
-        cli._resolve_template_path(template)  # type: ignore[attr-defined]
+        cli._resolve_template_path(template)
     assert excinfo.value.exit_code == int(ExitCode.INPUT_MISSING)
 
     monkeypatch.setattr(Path, "open", original_open)

--- a/tests/test_cli_success_paths.py
+++ b/tests/test_cli_success_paths.py
@@ -69,13 +69,15 @@ def test_resolve_template_unreadable(tmp_path: Path, monkeypatch: pytest.MonkeyP
 
     def fake_exists(path: Path) -> bool:
         if path == template:
-            raise OSError("no access")
+            error_message = "no access"
+            raise OSError(error_message)
         return original_exists(path)
 
-    def fake_open(self: Path, *args: object, **kwargs: object) -> object:
+    def fake_open(_self: Path, *_args: object, **_kwargs: object) -> object:
         class RaiseOnEnter:
             def __enter__(self) -> None:
-                raise OSError("cannot open")
+                error_message = "cannot open"
+                raise OSError(error_message)
 
             def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
                 pass

--- a/tests/test_date_envs.py
+++ b/tests/test_date_envs.py
@@ -21,6 +21,5 @@ def test_env_override_wins_over_today() -> None:
 def test_invalid_override_raises() -> None:
     invalid_date = "1999/12/31"
     frozen_today = date(2024, 1, 2)
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError, match=invalid_date):
         resolve_date(env={"ADR_DATE": invalid_date}, today=lambda: frozen_today)
-    assert invalid_date in str(exc.value)

--- a/tests/test_new_list_toc.py
+++ b/tests/test_new_list_toc.py
@@ -8,7 +8,8 @@ def test_new_list_and_toc(tmp_path: Path) -> None:
     log = AdrLog.init(tmp_path / "doc" / "adr")
     log.new("Use beartype on public API", status=AdrStatus.Accepted)
     rows = list(log.list())
-    assert len(rows) == 2
-    assert rows[1].number == 2
+    expected_records = 2
+    assert len(rows) == expected_records
+    assert rows[1].number == expected_records
     toc = log.generate_toc()
     assert "Use beartype on public API" in toc

--- a/tests/test_new_template_env.py
+++ b/tests/test_new_template_env.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from secrets import token_urlsafe
+from secrets import token_hex
 from typing import TYPE_CHECKING
 
 from typer.testing import CliRunner
@@ -81,7 +81,7 @@ def test_default_template_used_without_env_or_cli(
 
 def test_invalid_env_template_path_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _init_repo(tmp_path, monkeypatch)
-    missing = Path("/nope") / token_urlsafe(4) / "missing_template.md"
+    missing = Path("/nope") / token_hex(4) / "missing_template.md"
     monkeypatch.setenv("ADR_TEMPLATE", str(missing))
 
     result = runner.invoke(app, ["new", "Broken"])

--- a/tests/test_new_template_env.py
+++ b/tests/test_new_template_env.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from pathlib import Path
 from secrets import token_urlsafe
+from typing import TYPE_CHECKING
 
-import pytest
 from typer.testing import CliRunner
 
 from decree.cli import app
 from decree.core import AdrLog
+
+if TYPE_CHECKING:
+    import pytest
 
 runner = CliRunner()
 
@@ -19,7 +22,8 @@ def _init_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 def test_env_template_used_when_option_missing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo_dir = _init_repo(tmp_path, monkeypatch)
     env_template = tmp_path / "env_template.md"
@@ -60,7 +64,8 @@ def test_cli_template_overrides_env(tmp_path: Path, monkeypatch: pytest.MonkeyPa
 
 
 def test_default_template_used_without_env_or_cli(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo_dir = _init_repo(tmp_path, monkeypatch)
     sentinel_template = tmp_path / "sentinel.md"

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for individual decree modules."""

--- a/tests/unit/test_title_module.py
+++ b/tests/unit/test_title_module.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -20,6 +20,9 @@ from decree.title import (
     _split_suffix,
     _title_from_slug,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_resolve_adr_dir_validation(tmp_path: Path) -> None:
@@ -94,7 +97,8 @@ def test_rename_to_slug_conflicts(tmp_path: Path) -> None:
     dry_run_target = tmp_path / "0010-dry-run.md"
     dry_run_target.write_text("content", encoding="utf-8")
     new_path, renamed = _rename_to_slug(dry_run_target, "Preview", dry_run=True)
-    assert renamed and new_path.name.endswith("preview.md")
+    assert renamed
+    assert new_path.name.endswith("preview.md")
     assert dry_run_target.exists()
 
 
@@ -131,7 +135,8 @@ def test_link_rewrite_helpers(tmp_path: Path) -> None:
 
     assert not _needs_link_update("No match", candidates)
     suffixed, suffix = _split_suffix("target.md?query")
-    assert suffixed == "target.md" and suffix == "?query"
+    assert suffixed == "target.md"
+    assert suffix == "?query"
 
 
 def test_title_from_slug_and_config(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- configure Ruff to select the full stable rule set with COM812 ignored for formatter compatibility and keep tests exempt from docstring and assert rules
- upgrade the Ruff pre-commit integration and add package markers so the expanded linting surface can import scripts and tests cleanly
- document CLI and core modules, tighten error handling, and update supporting scripts and tests to satisfy the broadened lint feedback
- restore the CLI exit-code tests to the original subprocess helper to keep the coverage simple and aligned with existing expectations

## Testing
- `uv run py.test -vvvv` (42 tests)
- `uv run pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68e8c6908be88326a211278285c7657a